### PR TITLE
feat: add bulk inserts

### DIFF
--- a/snowflake_utils/models.py
+++ b/snowflake_utils/models.py
@@ -380,7 +380,7 @@ def _inserts(columns: list[Column], old_columns: dict[str, str]) -> str:
 
 
 def _type_cast(s: any) -> any:
-    if isinstance(s, int):
+    if isinstance(s, (int, float)):
         return str(s)
     elif isinstance(s, str):
         return f"'{s}'"

--- a/snowflake_utils/models.py
+++ b/snowflake_utils/models.py
@@ -1,6 +1,5 @@
 from enum import Enum
 from functools import partial
-import json
 from pydantic import BaseModel
 from snowflake.connector.cursor import SnowflakeCursor
 from typing_extensions import Self

--- a/tests/cassettes/test_bulk_insert.yaml
+++ b/tests/cassettes/test_bulk_insert.yaml
@@ -1,0 +1,820 @@
+interactions:
+- request:
+    body: !!binary |
+      H4sIAMn5hmYC/21Sy26DMBD8FcSplYqFCURtb65xEitgu7ZDlBOieauBSBFVVEX8e22IUvq4WN6Z
+      We/sri/uqqgL99m5uDihhOkcCZHT2CCu+Kx3xwofq2q9rI8n98HpazIiFeXMCgfgEUBLq4zlkmT0
+      SlQfh4NBEcZ8ZrIYSomVz9MpzqjwtA4GEQxsYsLHlN0EJKELhuKUsl5NwjIqOUvNvbVrPCQUI331
+      8I9ZriwRF6fzvurivumyWHLlwRBEXnEqh6E9vWH4tq+tViz0hLOfTUIIoh4nTU+0M4y76j0S81TQ
+      hMiWPRTV1oER8IHv3C1t5MHI9wE0SACi+9YcViJPedy+N0I0ybkgbf9aIkzZ2OAD/zYqW5nP9PeQ
+      GdFzLqd/CcXxlOhfeGOdIqVMSrvq8rwDxaZ82m7ewSt6CXardbtPomz7uUDSrEabYfR/ipBkRDSe
+      5HoiCYotFzZN8wXyhrpnUwIAAA==
+    headers:
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '361'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PythonConnector/3.8.1 (macOS-14.5-arm64-arm-64bit) CPython/3.11.5
+      accept:
+      - application/snowflake
+    method: POST
+    uri: https://00000000-0000-0000-0000-000000000000.snowflakecomputing.com/session/v1/login-request?request_id=00000000-0000-0000-0000-000000000000&databaseName=00000000-0000-0000-0000-000000000000&warehouse=00000000-0000-0000-0000-000000000000&roleName=00000000-0000-0000-0000-000000000000&request_guid=00000000-0000-0000-0000-000000000000
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEA51X23KiWBR9769I+ZpORxRRUzUPBzjIabkJBw1OTVGIKCRcjHhNV//7bLzE7sbL
+        ZPIW5CzWXnvty/nx5e6uMvYWXuXu6e5H8U/i5YtgTrPXIC2eVVbB/Kn+EEbp4qnRbtZbzWq1XuVa
+        bJ19wFTNxSlCaMg/Gs1HA/Emb/bVVa/6XVQYXukxKmN3pNdhJ14O1xghHiFsmEtMxvePE2/SCOt6
+        qpsjP3UARJgmr7VaJLTeHusdDdNGnc629y/baNTXfZtP1WmSzrY4idoJM9uYSbQZLL+38Hoat0ez
+        dqv1eF+vTafsUluJ+H39OJaa4n30OpuxxrY342wro+2ZogPmKKq9NJvVsH0/7Kmho3ZeNS41nWnP
+        yH2p2zYyq6YLan07ZCOeH/HNpL7J1z67yjYALG+fHb8VSt3Hld98m6F1N+GSjc1RRraIY0ptw+aD
+        kMsW3kBDzvpthJDNNMO3l/iltwy7+fPcbBhelsa6eB+r5K/K10L0xf+Qe/Hf5JbsRrwapo9N7iVj
+        WzxKB615XsiNZoYUhjXcR++5/xxVAyVmzBdLH9YXnLMhaNFbOu+9WrJ67wbsW7VrV82emutc2+HI
+        aDNRY4kuN2TwZvOdam29imxvxDTzviK/t0Jn+daSedxhveXSIV27M+GrsjTw1fecEZ4z+qy8oWZt
+        6TPN+zgR+W3amS1qSdwX64SzGlkwwcPqoJGteIlp+DOfIEl8bYXeK16FUXM1Xjc7Kat3bbwRPLm/
+        l3DlxdE4WmxJagV+lo7zwr11rlrdCbx3df/cOwzLHl4aR/ks9rZ2Hsw1Lwl29t+DwxOog34wz6Ns
+        XxatbzX2G7P/dRLN84WSTaPdT4v5Mth9cx4kavBRSOkyjk+PzzLZUw0DL16EQhj4rySFUoTACiZs
+        Y3c6DdZCHAXpQsrm9mw698Y7nh/oeZAXHMm4OHMsWLbZrrFVbgcw8+YQG+DuBPp7V/TgwPQYMCUq
+        tihSDVe3qWFTV9JNFdFdpPAesFnulXHg70FVH0TxTpZr7JNKnizrmyTV7+hQpkO1Asb++bWELygE
+        a9Q1TCxhKsgulU2MRKuEz54/XtC7xexE5zoHE1u2Ql1BtrWua5EhLpFguOplGnuV6PAWneskLGxZ
+        RNfcLsaGixTSL7OYeHEenOdxUFPFFImIIte2sHtELB7wyPoUXs/GpuMKukbxMyiDBBnwzinTuMoH
+        rOPqkssjTXQpVjDwA1isIV7BYknlK/Htj7ggdQeI1ME2pI8AkUDGwJgQr4uRRd19Jf7qzyugB9EO
+        6b/pROZ8qKdC0W574GKxXDfHR15NDJmBOIv8QnY0LNDCNAJ9/oyah8BlXQPpDv8A90LI36IpYRY9
+        7bwKHwZUdciwQlRSbhVMo85dPX36OHUM7KrIMIjWKbGonN5T6PCCcoZDIT7X0vSBgczuviJ6CrhY
+        NRQiEWyWcC9HV3xwqGvlEqrYVLhA4OPLx5wVIEVBEGCFIXlnml2Lgxl0XqJDPIek7yyPXQ1pOjJN
+        ffCJWC643oKdqNx9a+fJHD1zs6QvS3qAKIzcZ9x9v0EG+XwgIrGKdgKyCkSEkVIO4iaJ4wDQFVuF
+        YoJeCWgW1ixCP9uHrf4vJXRpZF5wDE80BMVzY97K+PnC+YOkh16p6B2IQtKLpkmh8xbDFpkIWgk2
+        yxrdbpOn/n0YLApMrIu9/LLmMI5uTu5Tm7weKggsYBgGOoVG6BIYMnoXa5/3EFQVpPs46C7i3BZp
+        P6CgJJHjQjpFaF+7zcaSdaU88LhGrXWh3A+5PM7w01bgyhiZlMcINrJdZ9EEpxRwse9erdwjrqCc
+        62pX4kQ21QVdPdfeL6f8t359y98XMn6unwuFkwxAJ0NUzMGSDh+B3P2zW3qPW3E6yYq9uLjowq5Q
+        3HtHXh58LPsW7Cu8/jFScz8MEu/463HFhoNrbx6E2fKXkyAN7MrYHchHLvMsPgEjQdBtDXY0lWj7
+        OIFBJRqXbweHZ/1zN5X9/WAe5LMszQPxcGs/8qokE6+Md3x4HvDLz508fvbHLSKBW4Q3/eNmsfR9
+        eFzot8v4z38BoV4wFDwQAAA=
+    headers:
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1556'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 04 Jul 2024 19:36:42 GMT
+      Expect-CT:
+      - enforce, max-age=3600
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding, User-Agent
+      X-Content-Type-Options:
+      - nosniff
+      X-Country:
+      - Brazil
+      X-Frame-Options:
+      - deny
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!binary |
+      H4sIAMr5hmYC/zWOwQqCQBRFf+Ux6xY6i5J2Nk00UBnNBG0nfYGgY/oUFPHfewUt77n3wJ0FtZXD
+      sRdbEOqmU6fBqqM+p2AOcMkc6IexzsL1vjsZJVYgPE0h1yPmrLx8RciMsB0w5GgKhjEDjt1kh2dd
+      EpVNcGWN32Yjo1jGSSQTuebV23e+xh474nJe/p5qQs+X9i774eUDXwLSz6UAAAA=
+    headers:
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '161'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PythonConnector/3.8.1 (macOS-14.5-arm64-arm-64bit) CPython/3.11.5
+      accept:
+      - application/snowflake
+    method: POST
+    uri: https://00000000-0000-0000-0000-000000000000.snowflakecomputing.com/queries/v1/query-request?requestId=00000000-0000-0000-0000-000000000000&request_guid=00000000-0000-0000-0000-000000000000
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEA4VWW2/iOhB+318R5RlWSSiX5c0E01jNbRPTFlYrKwV3yxEQTi49i6r+9zPOhRhK
+        2j5UZGLPfPPNzJd5+6Yo6jrKIlUZK2/wAI+HKIl2PONJKoy/3tQ9PKpjlRIHhxQ5PvPm1J9TNvMC
+        B1G1o75G21ycWMBf13G606liWcbN2CHjMPw+m/UUurTo0lHfOydvpk2wS5kf4BmmpsWoFWA0DRtv
+        N9JhEbo1ahPqiv8Ah3ObMtOau3csJEvcBNAH2kWIMju6bA11JUCIw5B4LrvD2GfIJvdShOdom3Ip
+        RpWzgymaIorYPMSsvi8MExR+cvvnHAcLZnouxY+QETItuH2WUf9jLCgV82Zsgtwpo9jGEBucYBdN
+        bDxtuLhEWh5gQMgtBOlBmcg9gvsEWISyA3KGUUiZ3u6iSrYqQHuddQl002LuJ1VobbMr5TlxHWDg
+        DxALzoFDF5tUlM2kj1+mYHkupFzlA7gEAWdIGw9Zkl8tuOMB6zZxiDQuer83kHKv/Z+mjC58zBzk
+        +8S9bSJIY2jTpZyxv6CAlIWu9+Cj4K7srp829Ijj22RGcNB4ucApsll6rtR86pyasvOT15pHcUU0
+        F4GIGAiVR3c0uNHk2aqQVbQX7YOZi1wPBYH30IqqpYNC26OSThhXOGxv9IvEqxCiKe51Vk4Y8slX
+        kKYkFAMEyZtkCjImwbkeoJYhz5470HQw53A3xG5I6OeKEd5LrfZBcOUKTYiLoMnatNnCj/LpKvFq
+        zm3vFvDMPDHwFDRCCDMKEAwPDqTcLlWibtkT3ZWY2aCJHzXmghkQvHZNb0b8CmigwcQgSR6FIWYE
+        hM27w+5XNYPuA8Jr4fx4qyW5UgKhUdGCAcVTGMbiWxVani0J6KBvjOSWr6ip1b35OjALo4BOMILv
+        ZzFLrrlooPcGZ4Nz4cW0z2b0EjGaU8/0nDORuSC9kS0Qj9ZekTm/piqmqJwPvsgSCRVt8JeQlN+d
+        cpVI4v+y44Gf7xFpFmV5CnfE3vEUpWJzgKd09cJ3Ufkb7NvKvM+32/JJpNJRn44Zt/n+T/aijvXB
+        cDg09EFHLaKM1Yz/zcDV9sP7dBUJh8JZRz0kfLVJN/G+NqxiiJGdDO8y/pRnBfxfqj+f2MRUom3C
+        o/VR4X83aZZ2FJEO3/F9pqT5asX5mq+/q79PLrI4i7bCg15zwrM82fO1bPs358mRFCZV05/6w54+
+        6mq61uty/Yl3NU0zuvpz39C0obbuPRtq5atm0E/i182aJ8JnkWNJ//NmH22nFcuu2OLgvRrCLjDx
+        4LMnHQoL8usjly4eooS/xHnK6wMqtBlsgJg9WGdugnjbnEGm6c1dWHUcAh1SBtvnuyeeeM+TzX5d
+        rJda9SJKkugorGF+OMRJVvJTtFN14sQzhY4quTJuRj2jev0K+6qooMR0yvfrgKf5NqObMnd9aGi6
+        oY+0nqb1qosF9+WxWZzsoqLc6j8p+JJPmPG+6C7wX+7JsClD0ZMNL9fkkxXsm6KSVWrFTp0BAEhg
+        dyjw1SiMHz9GN/0KSLl7J5s42WRHcUwrKFMUaMfi1zv8fxeQ1FW8LkpZ10kF52n059xWdGNagBOT
+        8+39f5cBhYPsCwAA
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1209'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 04 Jul 2024 19:36:43 GMT
+      Expect-CT:
+      - enforce, max-age=3600
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding, User-Agent
+      X-Content-Type-Options:
+      - nosniff
+      X-Country:
+      - Brazil
+      X-Frame-Options:
+      - deny
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!binary |
+      H4sIAMv5hmYC/02Oy2rDMBBFf0XMqoFQbKehTneKrYXBrY2jLkpdiupMiyCWE0mBGON/76gvupwz
+      d86dCdzpIPHi4Y5B1gguBasa1oi65Jlgkm9LwerHbVlk1/WTFDvJrloo8haYNh4/0C5ZCw/8XhDx
+      5AljWfFc5K9cBqZ7dF71xwUsGSg3mk5csKO6d3VwSMzh6Yymw2JPMCFAox1357deO6cHI8lAm/g2
+      ieIkTqNVlK4pdVRW9ejROlpO8+9dNpjwRi6rgAGNtxpD5HkCHRoiSv499d+bbDbpzXoV1FYPVvvx
+      J919K79q5pd5/gTU7P+NNAEAAA==
+    headers:
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '247'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PythonConnector/3.8.1 (macOS-14.5-arm64-arm-64bit) CPython/3.11.5
+      accept:
+      - application/snowflake
+    method: POST
+    uri: https://00000000-0000-0000-0000-000000000000.snowflakecomputing.com/queries/v1/query-request?requestId=00000000-0000-0000-0000-000000000000&request_guid=00000000-0000-0000-0000-000000000000
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEA4VWXXOiShB9319B8axbIIlavo04BirAsDAm0a2tKdRx11sqXj6y10rlv98ePmQ0
+        kuQhJc1M9+nTp5t++6Yo6jrKIlUZKW/wAI/HKIn2PONJKow/39QDPKojldouDilyfUZm1J9RNiWB
+        i6jaUV+jXS5OzOGv67rdyUSxrN7dyLVHYfh9OjUUurDowlXfO2dvpmNjjzI/wFNMTYtRK8BoEjbe
+        7qTDInRr1CbUDf8BDmcOZaY18x5ZaC9wE0Dva1chyuzoojXUjQAhDkObeOwRY58hx36SImyiXcql
+        GFXOLqZogihisxCz+r4wjFH4ye0fMxzMmUk8il8gI2RacPsio/uPsaBUjEzZGHkTRrGDITY4wR4a
+        O3jScHGNtDzAgJAHCGJAmewnBPdtYBHKDsgZRiFleruLKtmqAO111iXQjcS8T6rQKrMb5TlzHWDg
+        DxALzoFDD5tUlM2kL1+mYBEPUq7yAVyCgAukjYcsyW8W3CXAumO7ttQu+r3Rl3Kv/Z+7jM59zFzk
+        +7b30ESQ2tChCzljf04BKQs98uyj4LFU1w8HNOL6jj21cdB4ucIpslkQTxKfOqOm7PzsteZRXBHi
+        siEiBkLl1h327zS5typkFe2FfDDzkEdQEJDnVlQtCgodQqU50bvBYbvQrxKvQghRPOms7DDk219B
+        mtihaCBI3rQnMMYkOLcD1GOIODMXRAd9DndD7IU2/XxihE+S1D4MXLlCY9tDILK22WzhF/l0lXjV
+        5w55ADxTIhqewowQgxkFCJoHB1Ju11OiluyZ7mqYOTATP86YK2Zg4LXP9KbFb4AGGkwMI4lQaGJm
+        w2Ajj9j7qmagPiC8Hpwfb7UkV45AECqaM6B4As1YfKtCizjSAO3f94ay5Ctq6unefB2YhVFAxxjB
+        97PoJc+cN9CN/kXjXHkxnYsevUaMZpSYxL0YMlekN2MLhkerVmTOb00VU1TOB1/2Aokp2uAvISm/
+        OuUqkcR/s9ORX+4RaRZleQp3xN6xjFKxOcBTuvrD91H5G+y7ynzId7vySaTSUQt/IzXj/2VwaXnK
+        uMMPv7M/6kjvDwaDnt7vqLsPlnQVCYfCWUc9Jny1TbfxoTasYoiRnQ3vMv6UZwX8nyoVMBTgAz4j
+        SpqvVjxNN+DwpKwSHmV8/V39db6ZxVm0Exf1mgqe5cmBr2XbvzlPTnZhUjV9eT8w9GFX0zWjy/Xl
+        sqtpWq+rb+57mjbQNsYwUitfNXF+Er9u1zwRPovUStY320O0m1TkemJ5g/dqCCvAmMDXTjoUFpzX
+        R65dPEcJ/xPnKa8PqKAuWPwwe7Yu3ATxrjmDTJPMPNhwXBuEUQY75PslT8hmvD2si61Sq15ESRKd
+        hDXMj8c4ARIF1kJF1QmhFr7nh4yCkEquendDw6hev8KaKgonMZ3ywzrgab7L6LbMXR/0NL2nDzXD
+        6A+riwX35bFpnOyjosrqPyn4kk+Y8aGQGvgv12NYkAFMsuXldny2gn1bgK9SK1bpDABAAvtjgU9C
+        Yei9KoNy5U62cbLNTuKYVlCmKKDC4tc7/H8XkNRVvC5KWddJBedp9PvSVglTeBIN8+39fyBfxqjj
+        CwAA
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1200'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 04 Jul 2024 19:36:43 GMT
+      Expect-CT:
+      - enforce, max-age=3600
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding, User-Agent
+      X-Content-Type-Options:
+      - nosniff
+      X-Country:
+      - Brazil
+      X-Frame-Options:
+      - deny
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!binary |
+      H4sIAMv5hmYC/21PUUvDMBD+KyEv3aCTJC1O96azD4WxDZsJoiKxPSHQpl1yg5XS/+516oPgcXDc
+      d999393Aw7HWcEa+YjzfFtmjZvlW79j+cL/J11f7Z50VemarmDnTQMzq1lRQvRucvzr2TzzdbQ5Z
+      wWYyZhFCwIiqEipdiOVCpFqI1SWjOY8ZN6F3ZXaGktw/TR1Inwc4nsCVkFcEJgRQ6/vi9NHYEGzr
+      tG2AJnKphFTyRiRpekuszni6D8EHGg7j7966dUjfPejdBHNw6C1MlJeB28lBEBNJMqBpuj+6yXUi
+      1XRA523rLfY/7PJb8mIzvo3jF+pi96NDAQAA
+    headers:
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '255'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PythonConnector/3.8.1 (macOS-14.5-arm64-arm-64bit) CPython/3.11.5
+      accept:
+      - application/snowflake
+    method: POST
+    uri: https://00000000-0000-0000-0000-000000000000.snowflakecomputing.com/queries/v1/query-request?requestId=00000000-0000-0000-0000-000000000000&request_guid=00000000-0000-0000-0000-000000000000
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEA4VWW3OqSBB+P7+CmmfdAi9J1rcRxkCF24ExiaZOTaEZT9hCdAGzJ5XKf9+eAQSN
+        JHmwMrfur7/+uun3H4qCnqMiQspEeYcFLPdRFm15wbNcbD69oxSWaIKo5ZCQYsdn3pz6c8pmXuBg
+        inroNUoO4sYC/vqO0zcMxTQHo4ljTcLwr9lsqNClSZcO+ugdrem2RVzK/IDMCNVNRs2AYCNsrI1a
+        l4XrTq+Nqwv2AxLObcp0c+7esdBaksaBdqWeuSijo8tOVxcchCQMLc9ld4T4DNvWfcvDJkpy3vJR
+        xewQig1MMZuHhNXvxcYUh1+8/jknwYLpnkvJI0SEdRNen0Q0/uwLUsW8GZti12CU2AR8gxHi4qlN
+        jIaLc6TlBQaE3IKTIaTJusfw3gIWIe2AnBEcUqZ1m6iCrRLQnWetBbqRmPtFFjpldiE9R64DAvwB
+        YsE5cOgSnYq06fTx2xBMz4WQq3gAlyDgBGljocgOFxPueMC6bTlWq1y08fCqFXtt/1hldOET5mDf
+        t9zbxkOrDG26bEfsLyggZaHrPfg4uCvV9dMGjTi+bc0sEjRWznCKaJae2xIfmlO9bfxoteZRPBHi
+        ssAjAULbpXtzNVLbtVUhq2iX8iHMxa6Hg8B76ETVoaDQ9mirTwwucNgt9LPAKxdCFPcaKysM+9Z3
+        kAwrFAUEweuWAW2sBeeyg7oNefbcAdFBncPbkLihRb/uGOF9S2qfGm47Q1PLxSCyrt5sksf27Srw
+        qs5t7xbwzDxR8BR6hGjMOMBQPCRoxXbeJWrJHumumpkNPfFzjzljBhped09vSvwCaKBBJ9CSPApF
+        zCxobN4dcb/LGagPCK8b5+dXHcGVLRCEihcMKDagGOW3KjQ9u9VAr8aDm7bkK2rq7t58HZhJcECn
+        BMP3U9aSqy8a6MOrk8I5s6LbJzV6jhjPqad7zkmTOSO9aVvQPDq10ub8UlfRReZ8sGUtseiiDf4S
+        kvKrV44S2e6/4m3PT+eI9LBd8UzZbRQ4zpU4zXlW8GcwIgaRVZSLUQJW+fqFb6Pyf9hPqu30kCTl
+        SjrrIelhgjbxH2lk9VZwm6e/ixc0EXd7KDlZ5etImFJ7aJ/xdZzHuxRNtL97aL0Dw4Vcincf7Shy
+        XsggnpCGfh0Pil0RJWJfq+PlxSFLAUZr798Dz94suYVUbTW+Hmo3fVVTh32urVZ9VVUHfW0zHqjq
+        tboZ3nBU2arJ8LPda/zMM2FTxlNSu4nTKDEqwlwxocE5CuE7P/Xgk9a6FEoe6yvnJh6ijL/sDjmv
+        LyCQEEx3hD2YJ2aCXdLcwbruzV0YYxwLsl86K/PqbaZx+ixHR7U6yIuokBvlgAkjJlwNIPdWnfqG
+        rubQ4AkMoZK3ylBzNt8DOxfOjG1iHPZJvIbTEoKE9lEBibIsehPwwsN+v5OiA8+ljMoYBFS+5WlB
+        QbZl0rTBeDSqDLzCUCwE0uBFOU+fA54fkoLGZRK064GqDbQbdTQc1cKQIiivzXbZNpJqQv/kYKsy
+        LW/ou7Tgf+ThkSsAk8VlNE/ViC7H9PiUGiCnAAAQwHYv8TUohuPR+Egh3Ntn8S6LizdxTZVxKwqo
+        vaQKfiVdUA7PUlO1YBAYz6Pfp3v5Yb2GbWFJdJofH/8DC5q2m1EMAAA=
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1238'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 04 Jul 2024 19:36:44 GMT
+      Expect-CT:
+      - enforce, max-age=3600
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding, User-Agent
+      X-Content-Type-Options:
+      - nosniff
+      X-Country:
+      - Brazil
+      X-Frame-Options:
+      - deny
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!binary |
+      H4sIAMz5hmYC/21PwWrDMAz9FeNLWkiH47p09LZ1OQRKWxZ3MLZSvEQDQ+KktgoNIf8+pdsOgxkd
+      rPee3pN6Hs6VhivyFePZNk+fNcu2esf2h8dNtr7bv+o01xNbxsyZGmJWNaaE8mRw+u7YP+/lYXNI
+      czaRMYsQAsqIPlJINRPLmVBaiNWtoimPGTehc0V6hYLiP00VKIAHOF/AFZCVBCoCqPVdfvmobQi2
+      cdrWQEyylCKRyb1QSo6q1nhaEMEHIvvhd27dOKTznvRuhDk49BZGyVvP7ZggSIlkGdDU7R/f+Xyh
+      FiPdett4i92Puvi2vMUMx2H4AgdVFUZEAQAA
+    headers:
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '255'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PythonConnector/3.8.1 (macOS-14.5-arm64-arm-64bit) CPython/3.11.5
+      accept:
+      - application/snowflake
+    method: POST
+    uri: https://00000000-0000-0000-0000-000000000000.snowflakecomputing.com/queries/v1/query-request?requestId=00000000-0000-0000-0000-000000000000&request_guid=00000000-0000-0000-0000-000000000000
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEA4VWW3OiShB+319BzbM5Bd6S9W2EMUyF28KYRFNbU0Rxl1OIHsDsplL576dnAEEj
+        SR5Szq3766+/bvrtm6KgdViESJkob7CA5T7Mwm1URFkuNp/eUApLNEGM2iRg2Pa4O2fenPGZ69uY
+        oR56CZODuLGAvyvbvjIMxTT7w4lNJ0Hwz2w2UNjSZEsbvfeO1nSLEodxzyczwnSTM9Mn2Agaa8PW
+        ZeG602vj6oJ9nwRzi3HdnDt3PKBL0jjQxuqZizI6tux0dcFBQIKAug6/I8Tj2KL3LQ+bMMmjlo8q
+        ZpswbGCG+TwgvH4vNqY4+OT1jznxF1x3HUYeISKsm/D6JKLRR1+QKu7O+BQ7BmfEIuAbjBAHTy1i
+        NFycIy0vcCDkFpwMIE30HsN7CixC2gE5JzhgXOs2UQVbJaA7z1oLdCMx55MsdMrsQnqOXPsE+APE
+        gnPg0CE6E2nT2eOXIZiuAyFX8QAuQcAJ0sZCkR0uJtx2gXWL2rRVLtpoMG7FXts/VhlbeITb2POo
+        c9t4aJWhxZbtiL0FA6Q8cNwHD/t3pbp+WKAR27PojBK/sXKGU0SzdJ2W+NCc6W3jR6s1j+KJEBcF
+        jwQIbZfuzXiotmurQlbRLuVDuIMdF/u++9CJqkNBgeWyVp/oX+CwW+hngVcuhCjuNV5WGPboV5AM
+        GogCguB1akAba8G57KBuQ641t0F0UOfwNiBOQNnnHSO4b0ntQ8NtZ2hKHQwi6+rNJnls364Cr+rc
+        cm8Bz8wVBc+gR4jGjH0MxUP8VmznXaKW7JHuqplZ0BM/9pgzZqDhdff0psQvgAYadAItyWVQxJxC
+        Y3PviPNVzkB9QHjdOD++6giubIEgVLzgQLEBxSi/VYHpWq0GOh71b9qSr6ipu3vzdeAmwT6bEgzf
+        T1lLjr5ooA/GJ4VzZkW3Tmr0HDGeM1d37ZMmc0Z607ageXRqpc35pa6ii8x5YIsuseiiDf4SkvKz
+        V44S2e5P8bqPTueI9LB9jjJlt1HgOFfiNI+yIlqDETGIPIe5GCVgla9+R9uw/A37SbWdHpKkXEln
+        PfT8WkRWlP4qfqOJOOwh6XOCNvFfaTY5OcxXoTCl9tA+i1ZxHu9SNNG+99BqB4YLuRRm3ttR5FEh
+        g3hCGvp5PCh2RZiIfa2ONyoOWQpOW3v/HaLslcotpGrPo+uBdnOlaurgKtKe4Zeq9q+0zaivqtea
+        1h+FqLJVk+Flu5d4HWXCpgyvpHYTp2FiVIQ5YkKDcxTAd37qwietdSmQPNZXzk08hFn0e3fIo/oC
+        AgnBdEf4g3lixt8lzR2s6+7cgTHGppD90lmZV3czjdO1HB3V6iAvwkJulAMmjJhw1Yfc0zr1DV3N
+        oRElMIRK3ipDzdl8D+xcODO2iXHYJ/EKTksIEtp7BSTMsvBVwAsO+/1Oig48lzIqYxBQo22UFgxk
+        WyYNcjIcVgZeYCgWAmnwojxK136UH5KCxWUStOu+qvW1G3WkXtcUSBGU12a7bBtKNaF/c7BVmZY3
+        9F1aRH/l4ZErAJPFZTRP1Ygux/T4lBogpwAAEMB2L/E1KMbD0fd+6aYc8LN4l8XFq7imyrgVBdRe
+        UgX/JV1QDmupqVowCIzn4a/TvfywWsG2sCQ6zbf3/wHz+D2EUQwAAA==
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1237'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 04 Jul 2024 19:36:45 GMT
+      Expect-CT:
+      - enforce, max-age=3600
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding, User-Agent
+      X-Content-Type-Options:
+      - nosniff
+      X-Country:
+      - Brazil
+      X-Frame-Options:
+      - deny
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!binary |
+      H4sIAM35hmYC/91VS2/cNhD+K8ZefIkDSbtONr32WqAFciyKxYgaScxSJENSXmsN//cOZ6h1fDCc
+      oAUa97AguXzM95gZPWyMG+Lml6s/HzYTxggD0uJh0wV9h+GQFp/Xmz+WNDr7q7MWVXJh8+5qPUG/
+      qJ3Nh7bv9+/rvBXdHNRL99YnldFo00FP3oWE3cGDOlL0mM/cgZn50MN1cpM56nT97urazlNL0fI0
+      WnfqDRwxL3RnIY+Kgx3CbJOeeMe7qO/5vE78x0QbGQA/opxfAg55mnDyvTYof1s1h0DgZNWh8/zY
+      0gG9rA4RU9J2ECAJ+FiGaXSbp622EJXWfOc4zEmbPDWaNAA1cozeTpDUyP87BRI4uSNafeb5bHWO
+      3EGCZ3wP+TmODNHWKiw+OQ5kdEwFQERDarMyHroukK3MhMLYDoJwSec8Op+j5NmX6KzAGQYil6do
+      aXMlKj6tEVIoZ3TGaXvNixiZaaf5xtcZZ/HHRl8AjROoPAak3ZhEwrn1wamCckCLQSsPidWZwyrr
+      RX7lAj/7u0f7+fNvTA1D0j0rTu4WaCcIdkXP0jIAiOPlQQ4w604yoMDpXEJ7x2dT8jJOzOteBnOe
+      xJNFADOhCUIcwZT8SXif7kBSlTIvJOfEtOjUEVmJE7ZtcKeI7AfQDUlyzXb2yqY1ZvDqSYmt3IVj
+      wH5NT36g5UNfTvzIYJxQ5JoqehDeJ6sg8kESA7lAvCdHk1jjQ1HorC9FEfVghZ7veO9SYgZS78LE
+      CROCZfgpgMKWgkuMtQToPUmjb/2UkoklQTrd9yV6FvEUgC2AMHjSE0vuYixP4L2X+ovcRLL0QHUm
+      yp/LQ2rMV9PBEkwwVGAiubWOipc6z6Uh9AQ7UTMTq1AFlJSQnDoQHrRx3VdTJ/maMlBmARE/7ET3
+      tGaZTWsq51pWBmKUYM5jAOqJrDnYzrGEI4L/yqdR6UkU72erLhm06t1pIekkCUnaPB5xObnAwHAC
+      XfLR5H6w4uaeuGIquVqwEkJcfc3KSwPkHjPQcuSCWUDK4KJae254kLygxpVWf6ROIQRYnrqGpwQr
+      q1k872E2aSQJjDgzFXCld6vI1ZjGgNBdWtM8PbU6F0rDcZTFa1Wo0iUXq6SmcrsXBedh4Fk7a0Od
+      PF4/bh7zl4moUz+ffP7y1B+bqm7qfdXsmw95+z/6PmZQ1PJsnGnsyfR0oIZOguWz1ETDctBdPl/V
+      7e3Hbb2/qepqe4N1izdVVTU3dX/bVNXHqtv2zbff1n39Mudttd/9LJypYv4tytXbYPxDLrfPKffb
+      PXy3y7vdp7fo8iuUq7fB+B+6jM9cbl7mvNs12/+Hy/idLv9MjH/I5f0zynXd3D6v5e3LnG/r2zfp
+      8iuUq9cY//X4N9l9teTCDgAA
+    headers:
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1044'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PythonConnector/3.8.1 (macOS-14.5-arm64-arm-64bit) CPython/3.11.5
+      accept:
+      - application/json
+    method: POST
+    uri: https://00000000-0000-0000-0000-000000000000.snowflakecomputing.com/telemetry/send?request_guid=00000000-0000-0000-0000-000000000000
+  response:
+    body:
+      string: "{\n  \"data\" : \"Log Received\",\n  \"code\" : null,\n  \"message\"
+        : null,\n  \"success\" : true\n}"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '86'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 04 Jul 2024 19:36:45 GMT
+      Expect-CT:
+      - enforce, max-age=3600
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding, User-Agent
+      X-Content-Type-Options:
+      - nosniff
+      X-Country:
+      - Brazil
+      X-Frame-Options:
+      - deny
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!binary |
+      H4sIAM35hmYC/6uuBQBDv6ajAgAAAA==
+    headers:
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PythonConnector/3.8.1 (macOS-14.5-arm64-arm-64bit) CPython/3.11.5
+      accept:
+      - application/json
+    method: POST
+    uri: https://00000000-0000-0000-0000-000000000000.snowflakecomputing.com/session?delete=true&request_guid=00000000-0000-0000-0000-000000000000
+  response:
+    body:
+      string: "{\n  \"data\" : null,\n  \"code\" : null,\n  \"message\" : null,\n
+        \ \"success\" : true\n}"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 04 Jul 2024 19:36:45 GMT
+      Expect-CT:
+      - enforce, max-age=3600
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding, User-Agent
+      X-Content-Type-Options:
+      - nosniff
+      X-Country:
+      - Brazil
+      X-Frame-Options:
+      - deny
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!binary |
+      H4sIAM35hmYC/21Sy26DMBD8FcSplYqFCURtb65xEitgu7ZDlBOieauBSBFVVEX8e22IUvq4WN6Z
+      We/sri/uqqgL99m5uDihhOkcCZHT2CCu+Kx3xwofq2q9rI8n98HpazIiFeXMCgfgEUBLq4zlkmT0
+      SlQfh4NBEcZ8ZrIYSomVz9MpzqjwtA4GEQxsYsLHlN0EJKELhuKUsl5NwjIqOUvNvbVrPCQUI331
+      8I9ZriwRF6fzvurivumyWHLlwRBEXnEqh6E9vWH4tq+tViz0hLOfTUIIoh4nTU+0M4y76j0S81TQ
+      hMiWPRTV1oER8IHv3C1t5MHI9wE0SACi+9YcViJPedy+N0I0ybkgbf9aIkzZ2OAD/zYqW5nP9PeQ
+      GdFzLqd/CcXxlOhfeGOdIqVMSrvq8rwDxaZ82m7ewSt6CXardbtPomz7uUDSrEabYfR/ipBkRDSe
+      5HoiCYotFzZN8wXyhrpnUwIAAA==
+    headers:
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '361'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PythonConnector/3.8.1 (macOS-14.5-arm64-arm-64bit) CPython/3.11.5
+      accept:
+      - application/snowflake
+    method: POST
+    uri: https://00000000-0000-0000-0000-000000000000.snowflakecomputing.com/session/v1/login-request?request_id=00000000-0000-0000-0000-000000000000&databaseName=00000000-0000-0000-0000-000000000000&warehouse=00000000-0000-0000-0000-000000000000&roleName=00000000-0000-0000-0000-000000000000&request_guid=00000000-0000-0000-0000-000000000000
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEA5VX23KiWBR9n69I+ZpOixFRUzUPBzjIidyEgwanpihUVCKCgsZoV//7bMRLd+Nl
+        krcgZ7H22mtfzo+/Hh5KI2/llR5eHn5k/8y9dOUnNJ75Ufas9OEnL9WnaRCtXmrNerVRZ5gqwzXY
+        KvuEqZqKE4RQny8bjVoV8SZvdtWPDvMqKhVe6VTUit2SZv1WuO5vMEI8QtiorCflVjqwvd26avcC
+        Zz1ZrlgAESZsz24v2bQeyWudmaQiJs15HH101Oanl3ibplQbWK+qscM7S3qOpmw1blm715iKfeed
+        DJ2+EnBaee6E79w7GfG7qLnh0mGfZdq79ziN2Te5yVbijRik9U1/WXMGXDsR52H7dTyfVZ2KjJCS
+        dMncX3vhurfbJhODmuvZK2K8zqry8Syv08k0dKSPkO/Jvbk/3ZQtdTmwdp8yHSO5zrRHNcViZ/jd
+        Hz8yj8qmJ9qCt+0gu8FNOGI4xsjhpWj7vlmErfZsN2UZn/279C0TffV1ubn2/5JbNVE/SdtSt5d+
+        yGEgsjRscnu5UVCljxJhd41J0Br0ajVtNu11maDB60vN89Nlq4y6Tg3Xt2m8XMzkcRJzr5w48Sc8
+        ZlvczGGEUX8x3jpl2VM1f8R3JjX19bHpW+8Vy1b0pqyTVlWXV9XBTuLUt9E4HkpjWW91u4+VYdcr
+        s/WWzGwjIhNvMexuapow2Hxay1CgLMvwI8bgnz/bb7xu9xwkaTJfkcJt2fEtRw7GS7vW00h5nrzZ
+        Xi7hhxcGo2C1JZHlD+NolGburXIMsxc4d3X30jsV+Fr+0ihIF6G3tVM/0by5v7d/Dg5PoA66fpIG
+        cV4Wje/P7PdK/us4SNKVEk+C/U+rZO3vv5n4c9U/FVK0DsPz44tMchZT3wtXU2HqD2ckglKEwDIm
+        bG1/OvI3Qhj40UqKE3sxSbzRnucJPfXTjCMZZWeOBcvW6xzTzOEXUEpzH3D3Av2zL3pwYHQMmBIV
+        WxSphqvb1LCpK+mmiug+UngP2KxzZRz4e1LVJ1F8kOVn9kUlL5b1XZKqD7Qv075aAmP//FbAFxSC
+        NeoaJpYwFWSXyiZGolXAZy8fz+jdY3amc5uDicGn1BVkW2u7FunjAokKx1ynkatE+/fo3CZhYcsi
+        uua2MTZcpJBukcXYC1P/Mo+DmiqmSEQUubaF3SNi9oBH1pfwOjY2HVfQNYrfQBkkyIB3SZnaTT5g
+        HVeXXB5pokuxgoEfwGIN8QoWCyrfiC8/4oLULSBSBduQLgJEAhkDY0K8LkYWdfNK/NWfN0APoh3S
+        f9eJlcuhngtFu++Bq8Vy2xynvJoYMgNxZvmF7GhYoJlpBPr2FTUPgcu6BtId/gHumZC/RVPAzHra
+        ZRVOBlR1yLBCVFJsFZValbt5+vxx6hjYVZFhEK1VYFE6v6fQ/hXlDIdCfK6l6T0Dme28IjoKuFg1
+        FCIRbBZwr0eXfbCva8USKtlUuELg9OVjzjKQrCAIsMKQvAvNrsHBDLos0SGeQ9L3lseuhjQdmabe
+        +0IsV1xvKTotdt/ny2SOnrlb0tclPUBkRu5W3LzfIIN8PRCRWFk7AVkFIsJIKQZxl8RxAOiKrUIx
+        Qa8ENAtrFqFf7cNW95cSujYyrziGJxqC4rkzb2X8duX8QdJDr1T0FkQh6VnTpNB5s2GLTAStBJtF
+        je63yXP/PgwWBSbW1V5+XXMYR3cn97lN3g4VBBYwDAOdQiN0CQwZvY21r3sIqgrSfRx0V3Hui5QP
+        KChJ5LiQThHa136zsWRdKQ48rvbcuFLuh1weZ/h5K3BljEzKYwQb2b6zaIJTCDjbd29W7hFXUC51
+        tRtxIpvqgq5eau/XU/5bv77n7ysZv9TPhcxJBqCTPsrmYEGHUyAP/+635uNWHI3jbC/OLrqwK2T3
+        3oGX+qdl34J9hddPIzUdTv25d/z1uGLDwY2X+NN4/ctJkAZ2Zez25COXJA7PwEgQdFuDHU0lWh4n
+        MCgFo+Lt4PCse+mmki/wiZ8u4ij1xcOt/cirNB97Rbzjw8uAf/3cyzOM/7hFzOEW4U3+uFmsh0N4
+        nOm3z/jP/wDvjhqtPBAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1555'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 04 Jul 2024 19:36:46 GMT
+      Expect-CT:
+      - enforce, max-age=3600
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding, User-Agent
+      X-Content-Type-Options:
+      - nosniff
+      X-Country:
+      - Brazil
+      X-Frame-Options:
+      - deny
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!binary |
+      H4sIAM75hmYC/zWOTQuCQBRF/8owyxBRKYt2+bEQIgUnqOU0PUFwxpw3giL+955By3vuPXAXjkMn
+      YHL8zDhCB8qxHWtsr1l9uWVJ+fCre3ItUr96irwW3GNc4mxUPoEip5EdgrepwwhGQfEmGBKgaOd6
+      fOkWse2NaDVszTEKwig8BfEh3tPqI63U4MAilcv699LeOPqUifKH1y+9X3/UpgAAAA==
+    headers:
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '163'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PythonConnector/3.8.1 (macOS-14.5-arm64-arm-64bit) CPython/3.11.5
+      accept:
+      - application/snowflake
+    method: POST
+    uri: https://00000000-0000-0000-0000-000000000000.snowflakecomputing.com/queries/v1/query-request?requestId=00000000-0000-0000-0000-000000000000&request_guid=00000000-0000-0000-0000-000000000000
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEA7VYWW/qyBJ+n18R8XqTGwOBLNI8tO02duIFvLBdjSwDTkKOWQZMFo7y329VtcHG
+        wDmah0GK0139de1V7fbPPy4uKpMojSoXDxc/YQLTZbSKZnEar9ZI/N/PyhymlYeKb1jc85nVDp3A
+        bwd+qDmuxfzKZeU9SjaIGMDvyrKuVPVC12s3D5bx4Hn/1bT6hT/U/aFV+b7cc1NMg9t+2Ha5xn1F
+        D33d5Uz1cm43BTCKPis1F3WCv8u9wPRDRQ/sp9AzhjwXUG1KJRHCOn94VtQJAR73PMOxwyfO2yEz
+        jW5BwnOUrOOCjMxmi/tMZT4LA4+Hu/1IkJn3i92dgLuDUHFsn/fBIqbosPvAosaxLAhV6GihzGw1
+        9LnJQTYw4TaTTa7mvihrKgAhOKQFQuoQJqPLYL8BXoSwg+YhZ54fVs+zyIzNAnA+ztWC0nmK2b+I
+        wtk0OxGeva9dDv4DjdHn4EObKz6GTfH7vzVBd2wwObMH9EIHHGiac0hXm5MBtxzwumlYRqFcqo16
+        s2D7jv++yvxBm4cWa7cNu5VLKJSh6Q+LFrcHPmgaerbTazP3SWRXx4QcsdqmoRnczbmU9ERrho5d
+        SL5K4CtF5nuuOz/iFkwuAyRycGixdO+aN1KxtjLNMrdT+vDQZrbDXNfpndXqTAZ5puMX+kTthA/P
+        J3rJ8EwEJkW3GooKY23jdyqphocFBMYrhgptrKDOaQG7NuSYgQVJB3UOez1ue4b/647hdQupdtRw
+        ixGSDZtBkp3rzTrvF9GZ4Vmdm04L9NEcLHgfegQ2ZuYyKB7uFmwrd4ldyu7dnTUzE3ricY8peQYa
+        3vmenpf4CaXBDQqHluT4UMShAY3NeeL272IG2QcO3zXO411njBMtEBKVDUJwsQrFSGeVpztmoYE2
+        G7W7Yspnrtl19/x0CHXOXF/mDM5PqiVbGeSq15sHhVPiopgHNVrWmAW+ozjWQZMpOT1vW9A8zuZK
+        0eenuoqCkWsDL2PIsIvm+guVLv66FK8Sq8VH+rWMD98jDHQbvnOMojW+NXhwNskOtuH1+DWeRUBq
+        B7JpKEABUIIY0AKaNxDmmyQRNLTssjL6SmMznr+kr5UHXIMtKPCh8jz9jCewITlYXI8j5CddVpar
+        eDxdTxfzykP97rIyXgDflKbIptBTbCgD4PNvKFxt3t7e1qrNvdJp/JkWdM7XM72FhQXVBeG88qbD
+        VK6G9Jb2b1hw4PJ0OovXaTRbhvN0WzBDgDIT7g9cD4EoK19MnnWcypAkzRvMoMo1/qovLcZYB/7w
+        98TYB5NfmMbYC1NeiCbLjFk4Uhgz8D/Md/9hhkvqB9DYksbEavMfYI1Q1f2Af2yBEmB/9hDDANnI
+        L7j1EZd8fi+7vMv7khbgHPQA9vgQmjwjUSP+axziRqZvm9fXd0SkOeO4QvsVpLaGy9FMW3f15GOI
+        8ye1hCdTPm0QQ1Jaj41Jq2sNe435pAVEyy/hkT84CX4Cby8G/ccc77ydwjcQL6N83X4b9D4TnCvt
+        9+vrTxyR0iIKKs3JH2P9MRnUkm3Uu98g1SQ8iSYlVOSnuY9+0PW7XLMD7d7paguC4mPUup9HPft1
+        pLmNcStAf8E+3CTPrtsiPuwV52y8jw85HUmgHz5aw69Bz5Z2OjA2AKJKTiNJOuoj/G0invgra4w/
+        KUlzEaourf+ApzyLeo29XsCvU8KTaMtHWShFnsZ9N/Fb3c2w7gJBlUp4Cj0lqcC/RS3tK8ezAdpb
+        1sch0zFV5O2gpq0pP9S3u+N8yuKNeF3+Gvbs5biWvI8wNbUt4scwEkYyCUeBF1S1oOrKfld+9hM3
+        wnUFXdX6fB/WEsyBIO7LSbYfl2Vy6uPqHvjBlCtQhECl+qAlmiMNpOJj2JffBzVUgrXw8YUPqGDY
+        hAwY+ZuEivyqt7fH+SbqifJtOEs2e72QQbt+iEdRKq/Bk6QM5ok0DD6T0WwiRUB8LOPRXyKfBb72
+        +jr+keO9k3jMD2HfuAa5C3kL9iyun4/jJ+KNePljPOu+RX17OardwFyxEK/DKGttNo66PLHdrh10
+        gmqnLzWCHrkOW4m8HtUmS8wB0SfEftzDUDxTn66hVGEgyy4lzY+8XmiOIBF/3pD9gDaJ/oWNRUSe
+        vSFIo/rN+xfbQir/g/6lqojHwsjyjYz4tN/GdXtrUB+DpZPx6bdvIZ6Ep1KgIoN42ttx3XqjuMJW
+        qrdS/SgG2l+uH+H/Uv08vZXsodTdOsCZ+nG5fiyynxwm+jf6Uw7c7qtwIjsVH8znQWY/VMoLNqUX
+        9DeEnPzbwWYLdPHrGMRLpzIgYh40OsrkRxel4hJlyi/OG02FzvYP4qX7J/CMuv7J8+bx7RSejDp5
+        3phQ00f6CCeUz5s69MCD8wbtVS0smJPnDeQHhLizP/dF/yHX0dD9kQzcgObU+svnjdgPcfkQ7wsg
+        B9jtgsIYaHN9LVF/y2KNgA+mvWA/C1AuyCfT4V9HNDmRhAjE3xMGDVoMULP3FTOLP67monC2e5+h
+        8fkH5SstU30cAXOmorURgOpRQKl/0ZCKsLxfpFaZikUnfqIIaIw1c/RTc/ll/SjeBVcX9pahYiln
+        VYDm9heIp/d3DrFC9dx+eI/aTnQ3Gdc7dDQJfurstZe5y4m04ZEOf/5ZyW476SKNEnxTre2uP3G6
+        Wc3hGlKg/b2JV18GkSpSddS4rVfvrqSqVL+Kq6P7K0mSalfV50ZNkm6rUm0U7Zjv3t7bq8X7dBKv
+        kCe9WIub1vN0HiVqdqmy8YMtvjHvr1YFkEeXrB2kzKIXreLXxWYd7wAVuFHCx14e9vSdKiTLXSQ5
+        himKE9jwVdMy4DIohM03s1G8cp7l6XxCX5KlbCFaraIvpHqb5XKxSoV/6OaYIeASkcazeJ76cJcT
+        vrqR7pvZ6jt8mcaLGhhY3W2I5xM3Xm+S1Ic7CK3c1qRqrXonNe/vduEg1wuYtljNopR8BOosPnZK
+        E0RZzOkiBgLEJ3H4KA7KrKax+CK+pwJ9SpHMTKPP5/tbUEmN2+Zt41boKz6zr6aL1TT9QphELru4
+        +L74i0bf8PxGLNyOJmTPLk4VuGKto5dD2nozHgMZOeGt+I/v/wNfLhq81xcAAA==
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '2326'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 04 Jul 2024 19:36:46 GMT
+      Expect-CT:
+      - enforce, max-age=3600
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding, User-Agent
+      X-Content-Type-Options:
+      - nosniff
+      X-Country:
+      - Brazil
+      X-Frame-Options:
+      - deny
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!binary |
+      H4sIAM/5hmYC/81VTY/cNgz9K4u57CUb2DPZj+baa4EWyLEoBrRM28rIkiLRO+tZ7H8vRcqz6SE9
+      FWgOA0kjinx8fKRfdy6Meff55s/X3Yw5w4h8eN31yT5jOtIay3n3x0pT8L8G79FQSLsPN5sF/7IN
+      vhgdPj59bMtVDksyP3q3uTTOoqejnWNIhP0xgjlx9FxsnsEtYvR6S2F2J0u3H25u/TJ3HK1ssw/n
+      wcEJy8H2HspqJNgxLZ7sLDcxZPsi9pbkj5kvCgBxYkJcE45lSzjHwTrUv71ZUmJweuoxRHG29sCe
+      zTEjkfWjAiEQswLT2a5sO+shG2vlzWlcyLqydZY5ADNJjMHPQGaS/4MBDUzhhN5eZL94WyL3QPCP
+      fI/FnUSG7FuT1khBAjmbqQLI6JhtYSZC3ycuq2TCYXwPSXOhS1lDLFHK7msOXuGMIydXtuj5cktU
+      67RFoFRtbMHpByuHnCXT3sqLbwsuWh+fYwU0zWDKmpBvMymFSxdTMBXliB6TNRFI2FnSRuuVfhOS
+      uP09ov/y5TdJDRPZQRjn6lZoZ0h+Qy/UCgDI09WhBFhsrwqocPpA6J/FlijqOkteL7q4y6w1WRWw
+      JDRDyhO4qh/CF3oGlSorL1EIWrQczAmFiTN2XQrnjFIP4BcqcivlHIynLWaK5p2Jg76FU8Jhk6c4
+      6MTo61mcjC5oitJTlQ/G+14qyGLIZKA0SIxcUdLSxFQZuthrU2Q7ek0v9nJ3bTEHNIQ0i2BS8gKf
+      EhjsOLjG2FqA/amMvq+ntkyuAuntMNTohcRzAikBpDEyn1i1i7m6wJeo/ZdliBTqgftMmb9UR2Yq
+      T+noGSY4bjCl3PvAzcuT5zoQBoZNPMy0VGgSqiRUU0fGgz5v92buVa9UgEoWkPHhk/JOm8o8bVIu
+      vWwc5KzBQsQEPBOFc/B9EAonhPhNrNHYWRkfFm+uCtr47q0mGVSETG1ZT7ieQxJgOIOtenRlHmy4
+      ZSZumKpWK1ZGiFtdC/M6AGXGjHycpGFW0Da4stZd9rKoLnhw0VYf7VNICdb3qRFZYPW0aM0HWBxN
+      TIHTyswVXJ3dJks30pQQ+utoWub3URdSHTiBVbx1halTcvVGe6qMe2VwGUfZdYt1PMnz7dvurXyZ
+      OHWe53MsX572cd+0+/apebh/+FSu/6fvYwHFI8/nhdeBi05HHuhMWLHlIZrWo+2LfdN294+H9umu
+      aZvDHbbdL3dN0+zv2uF+3zSPbbPv4Ptv61P745wfm4fDz5Izd8x/lfK/Z8xV/uvtb1HrMV8QCQAA
+    headers:
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '969'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PythonConnector/3.8.1 (macOS-14.5-arm64-arm-64bit) CPython/3.11.5
+      accept:
+      - application/json
+    method: POST
+    uri: https://00000000-0000-0000-0000-000000000000.snowflakecomputing.com/telemetry/send?request_guid=00000000-0000-0000-0000-000000000000
+  response:
+    body:
+      string: "{\n  \"data\" : \"Log Received\",\n  \"code\" : null,\n  \"message\"
+        : null,\n  \"success\" : true\n}"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '86'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 04 Jul 2024 19:36:47 GMT
+      Expect-CT:
+      - enforce, max-age=3600
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding, User-Agent
+      X-Content-Type-Options:
+      - nosniff
+      X-Country:
+      - Brazil
+      X-Frame-Options:
+      - deny
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!binary |
+      H4sIAM/5hmYC/6uuBQBDv6ajAgAAAA==
+    headers:
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PythonConnector/3.8.1 (macOS-14.5-arm64-arm-64bit) CPython/3.11.5
+      accept:
+      - application/json
+    method: POST
+    uri: https://00000000-0000-0000-0000-000000000000.snowflakecomputing.com/session?delete=true&request_guid=00000000-0000-0000-0000-000000000000
+  response:
+    body:
+      string: "{\n  \"data\" : null,\n  \"code\" : null,\n  \"message\" : null,\n
+        \ \"success\" : true\n}"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 04 Jul 2024 19:36:47 GMT
+      Expect-CT:
+      - enforce, max-age=3600
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding, User-Agent
+      X-Content-Type-Options:
+      - nosniff
+      X-Country:
+      - Brazil
+      X-Frame-Options:
+      - deny
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
this PR allows us to bulk insert records into a table from a dict input like the one used in the test:
```
    records = {
        "1": {"id": 1, "name": "test", "loaded_at": datetime(2024, 7, 4)},
        "2": {"id": 2, "name": "test2", "loaded_at": datetime(2024, 7, 4)},
    }
```

useful for loading data directly from memory.
supports only append mode.